### PR TITLE
improved makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,14 @@
 DIRS = $(sort $(dir $(wildcard */)))
 
-all:
-	@for dir in $(DIRS); do \
-		if [ -d $$dir ]; then \
-			(cd $$dir && $(MAKE)) || exit 1 ; \
-		fi \
-	done
+.PHONY: all $(DIRS)
+
+all: $(DIRS)
+
+$(DIRS):
+	$(MAKE) -C $@
 
 clean:
-	@for dir in $(DIRS); do \
-		if [ -d $$dir ]; then \
-			(cd $$dir && $(MAKE) clean) || exit 1 ; \
-		fi \
-	done
-
-
-.phony: all clean
-
+	rm -f */bench.X86
+	rm -f */bench.ARM
+	rm -f */bench.RISCV
+	rm -f */randArr.h 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
-DIRS = $(sort $(dir $(wildcard */)))
+DIRS = $(dir $(wildcard */))
 
-.PHONY: all $(DIRS)
+.PHONY: default all $(DIRS)
 
+default: PARENT = default
+default: $(DIRS) 
+
+all: PARENT = all
 all: $(DIRS)
 
 $(DIRS):
-	$(MAKE) -C $@
+	$(MAKE) $(PARENT) -C $@
 
 clean:
 	rm -f */bench.X86

--- a/make.config
+++ b/make.config
@@ -2,3 +2,4 @@
 #CC=/s/gcc-4.9.2/bin/gcc
 #CC=gcc
 #PY=/s/python-2.7.3/bin/python
+PY=$(shell echo `which python`)

--- a/make.rules
+++ b/make.rules
@@ -1,14 +1,15 @@
 include ../make.config
 
-CC?=gcc
+CC_X86?=gcc
+CC_ARM?=arm-linux-gnueabi-gcc
+CC_RISCV?=~/opt/riscv/bin/riscv64-unknown-elf-gcc
 OPT?=-O3
-MAGIC?=-DMAGIC
 
 #-fno-tree-vectorize 
-CFLAGS+=${OPT} ${MAGIC} -I../
+CFLAGS+=${OPT} -I../
 
 
-all: bench
+all: benchX86 benchARM benchRISCV
 
 
 ifneq ("$(wildcard rand_arr_args.txt)","")
@@ -22,12 +23,16 @@ else
 pre_req:
 endif
 
-bench: bench.c pre_req
-	${CC} ${CFLAGS} bench.c --static --std=c99  -lm -o bench
+benchX86: bench.c pre_req
+	${CC_X86} ${CFLAGS} -DMAGIC bench.c --static --std=c99  -lm -o bench.X86
+
+benchARM: bench.c pre_req
+	${CC_ARM} ${CFLAGS} bench.c --static --std=c99 -lm -o bench.ARM
+
+benchRISCV: bench.c pre_req
+	${CC_RISCV} ${CFLAGS} bench.c --static --std=c99 -lm -o bench.RISCV
 
 clean:
-	rm -f bench
+	rm -f bench.X86 bench.ARM bench.RISCV
 
 .phony : clean all
-
-

--- a/make.rules
+++ b/make.rules
@@ -12,14 +12,13 @@ default: benchX86
 
 all: benchX86 benchARM benchRISCV
 
-
 ifneq ("$(wildcard rand_arr_args.txt)","")
 args := $(shell cat rand_arr_args.txt)
 
 randArr.h: rand_arr_args.txt
 	${PY} ../rand_c_arr.py $(args)
 
-pre_req: randArr.h 
+pre_req: randArr.h
 else
 pre_req:
 endif
@@ -35,5 +34,3 @@ benchRISCV: bench.c pre_req
 
 clean:
 	rm -f bench.X86 bench.ARM bench.RISCV
-
-.phony : clean all

--- a/make.rules
+++ b/make.rules
@@ -8,6 +8,7 @@ OPT?=-O3
 #-fno-tree-vectorize 
 CFLAGS+=${OPT} -I../
 
+default: benchX86
 
 all: benchX86 benchARM benchRISCV
 

--- a/rand_c_arr.py
+++ b/rand_c_arr.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/python
 
 import random
 import argparse
@@ -45,3 +45,4 @@ for i in range(0,args.len):
 
 out_file.write("};")
 
+out_file.close()


### PR DESCRIPTION
Now we can make binaries for X86, ARM, and RISCV. I'm not really sure what to do with the magic number for X86, ie `ROI_BEGIN();` and `ROI_END();` in each bench.c file. I'm not sure what the functions do in ARM and RISCV binaries, but I ran the ARM and RISCV binaries and saw no different in terms of outputs compared to those of X86 binaries. 